### PR TITLE
Fix five crash paths in the bot and API

### DIFF
--- a/KotatsuTgBot/botHandlers.go
+++ b/KotatsuTgBot/botHandlers.go
@@ -289,7 +289,7 @@ func proccessRegistrationCallback(ctx context.Context, b *bot.Bot, update *model
 		ParseMode: models.ParseModeHTML,
 	}
 
-	if update.Message.Text == config.T("keyboard.continue") {
+	if update.Message != nil && update.Message.Text == config.T("keyboard.continue") {
 		full_tg_name := update.CallbackQuery.From.FirstName + " " + update.CallbackQuery.From.LastName
 		db_answer_reg := regUser(update.CallbackQuery.From.ID, full_tg_name, update.CallbackQuery.From.Username)
 
@@ -301,7 +301,7 @@ func proccessRegistrationCallback(ctx context.Context, b *bot.Bot, update *model
 		case db.DB_ANSWER_OBJECT_EXISTS:
 			params.Text = config.T("registered")
 
-			_, old_user := db.DB_GET_User_BY_UserTgID(update.Message.From.ID)
+			_, old_user := db.DB_GET_User_BY_UserTgID(update.CallbackQuery.From.ID)
 
 			if old_user.IsClubMember {
 				params.ReplyMarkup = keyboards.Keyboard_MainMenuButtonsClubMember
@@ -383,7 +383,7 @@ func BotHandler_Command_Start_Link(ctx context.Context, b *bot.Bot, update *mode
 			is_participant := false
 
 			for _, participant := range activity.Participants {
-				if participant.UserTgID == update.CallbackQuery.From.ID {
+				if participant.UserTgID == update.Message.From.ID {
 					is_participant = true
 					break
 				}

--- a/KotatsuTgBot/db/AnimeRoulettes.go
+++ b/KotatsuTgBot/db/AnimeRoulettes.go
@@ -258,10 +258,10 @@ func DB_UPDATE_AnimeRoulette(update_json map[string]interface{}) int {
 	for key, value := range update_json {
 		switch key {
 		case "status":
-			panic("Not supported")
+			return DB_ANSWER_NOT_SUPPORTED
 
 		case "current_stage":
-			panic("Not supported")
+			return DB_ANSWER_NOT_SUPPORTED
 
 		case "theme":
 			if v, ok := value.(string); ok && v != anime_roulette.Theme {
@@ -269,7 +269,7 @@ func DB_UPDATE_AnimeRoulette(update_json map[string]interface{}) int {
 			}
 
 		case "stage_new_date":
-			panic("Not supported")
+			return DB_ANSWER_NOT_SUPPORTED
 
 		case "start_date":
 			if v, ok := value.(string); ok {

--- a/KotatsuTgBot/db/DB_AnswerCodes.go
+++ b/KotatsuTgBot/db/DB_AnswerCodes.go
@@ -16,4 +16,5 @@ const (
 	DB_ANSWER_PERMISSION_DENIED          // Отказано в доступе
 	DB_ANSWER_DELETE_ERROR               // Ошибка удаления объекта
 	DB_ANSWER_UNEXPECTED_ERROR           // Незапланированная ошибка
+	DB_ANSWER_NOT_SUPPORTED              // Операция не поддерживается
 )

--- a/KotatsuTgBot/routes/api_activities.go
+++ b/KotatsuTgBot/routes/api_activities.go
@@ -41,9 +41,12 @@ func Handler_API_Activities_CreateObject(c *gin.Context) {
 	description := c.PostForm("description")
 	location := c.PostForm("location")
 
-	files := c.Request.MultipartForm.File["send_images"]
-	if len(files) <= 0 {
-		files = c.Request.MultipartForm.File["send_images[]"]
+	var files []*multipart.FileHeader
+	if c.Request.MultipartForm != nil {
+		files = c.Request.MultipartForm.File["send_images"]
+		if len(files) <= 0 {
+			files = c.Request.MultipartForm.File["send_images[]"]
+		}
 	}
 
 	uploadDir := config.ByUI("./img/activities/")

--- a/KotatsuTgBot/routes/api_anime_roulettes.go
+++ b/KotatsuTgBot/routes/api_anime_roulettes.go
@@ -151,6 +151,10 @@ func Handler_API_AnimeRoulettes_UpdateObject(c *gin.Context) {
 		Answer_NotFound(c, ANSWER_OBJECT_NOT_FOUND().Code, ANSWER_OBJECT_NOT_FOUND().Message)
 		return
 
+	case db.DB_ANSWER_NOT_SUPPORTED:
+		Answer_BadRequest(c, ANSWER_INVALID_COMMAND().Code, ANSWER_INVALID_COMMAND().Message)
+		return
+
 	default:
 		Answer_BadRequest(c, ANSWER_DB_GENERAL_ERROR().Code, ANSWER_DB_GENERAL_ERROR().Message)
 		return

--- a/KotatsuTgBot/routes/api_requests.go
+++ b/KotatsuTgBot/routes/api_requests.go
@@ -135,6 +135,8 @@ func Handler_API_Requests_UpdateObject_Choice(c *gin.Context) {
 		b, err := bot.New(config.GetConfig().CONFIG_BOT_TOKEN, opts...)
 		if err != nil {
 			rr_debug.PrintLOG("api_requests.go", "Handler_API_Requests_UpdateObject_Choise", "gotgbot.NewBot", "Ошибка инициализации бота", err.Error())
+			Answer_BadRequest(c, ANSWER_BOT_CONNECT_ERROR("").Code, ANSWER_BOT_CONNECT_ERROR("").Message+" Error: "+err.Error())
+			return
 		}
 
 		params := &bot.SendMessageParams{


### PR DESCRIPTION
Five defects that either terminate the bot process or panic a request handler. Found while reviewing `dev` at d9487df.

Context for why the first two are severe: there is no `recover()` anywhere in the codebase, and `go-telegram/bot` v1.14.0 dispatches handlers with a bare `go r(ctx, b, upd)` (see `process_update.go`). An unrecovered panic in any goroutine terminates the whole process, so these are full bot outages, not single-request failures.

### 1. `proccessRegistrationCallback` — guaranteed nil deref

`botHandlers.go:292` read `update.Message.Text`, but the function is only reached from the `update.Message == nil` branch at `botHandlers.go:58-69`. Every inline-button press by a user who isn't yet in the DB crashed the bot.

The function is a copy of `proccessRegistrationMessage` with `update.Message` → `update.CallbackQuery` substituted, and two sites were missed. Guarded the text check and switched the id lookup to `CallbackQuery.From.ID`, which is the field actually populated on this path.

Note for review: with the guard, the `if` branch is now provably unreachable on the callback path — a reply keyboard produces a message, not a callback, so `keyboard.continue` never arrives here. I left the branch in place rather than deleting it, since removing it is a behavioural call that's yours to make. The `else` branch (greet + show the registration keyboard) is what actually runs, and that looks correct for an unregistered user pressing a button.

### 2. `BotHandler_Command_Start_Link` — nil deref on deep links

Registered as a message handler (`main.go:42`), so `update.CallbackQuery` is always nil, but the participant loop at `botHandlers.go:386` read `update.CallbackQuery.From.ID`. Any `/start <activity_id>` deep link to an activity with at least one participant crashed the bot. Now uses `update.Message.From.ID`, consistent with the rest of the function.

### 3. `DB_UPDATE_AnimeRoulette` — reachable `panic("Not supported")`

`PUT /api/roulettes/` with `status`, `current_stage` or `stage_new_date` hit a bare panic. Gin's Recovery contains it as a 500, but it's user-reachable. Added `DB_ANSWER_NOT_SUPPORTED` and mapped it to a 400 in the handler.

### 4. `Handler_API_Requests_UpdateObject_Choice` — nil bot used after failed init

`bot.New`'s error was logged and execution continued, then `b.SendMessage` dereferenced nil. Now answers and returns.

### 5. `Handler_API_Activities_CreateObject` — nil multipart form

Indexed `c.Request.MultipartForm` with no nil guard, so a non-multipart `POST /api/activities/` panicked. Guarded the same way `Handler_API_Activities_UpdateObject` already does.

---

Verified with `go build ./...` and `go vet ./...` on go1.23.6 — both clean. No behavioural change beyond the crash paths; no tests exist in the repo to run.

Not addressed here, but worth separate issues — the review also turned up a missing admin check (`middleware.CheckIsAdmin` is defined but never called, so any support-chat member can wipe all users or broadcast), `.(int)` type assertions that never match JSON numbers so several API fields are silently ignored, roulette updates always editing the first row, and a self-assignment bug in the roulette pairing in `cron.go`. Happy to open those as issues or follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
